### PR TITLE
Complete puppet server test batch handlers

### DIFF
--- a/tests/puppet-server-impl.ts
+++ b/tests/puppet-server-impl.ts
@@ -268,6 +268,60 @@ export const puppetServerImpl: IPuppetServer = {
     throw new Error('not implemented.')
   },
 
+  messageBatchSendText: (call, callback) => {
+    void call
+    void callback
+    throw new Error('not implemented.')
+  },
+
+  messageBatchSendFile: (call, callback) => {
+    void call
+    void callback
+    throw new Error('not implemented.')
+  },
+
+  messageBatchForward: (call, callback) => {
+    void call
+    void callback
+    throw new Error('not implemented.')
+  },
+
+  messageBatchSendContact: (call, callback) => {
+    void call
+    void callback
+    throw new Error('not implemented.')
+  },
+
+  messageBatchSendUrl: (call, callback) => {
+    void call
+    void callback
+    throw new Error('not implemented.')
+  },
+
+  messageBatchSendMiniProgram: (call, callback) => {
+    void call
+    void callback
+    throw new Error('not implemented.')
+  },
+
+  messageBatchSendLocation: (call, callback) => {
+    void call
+    void callback
+    throw new Error('not implemented.')
+  },
+
+  messageBatchSendChannel: (call, callback) => {
+    void call
+    void callback
+    throw new Error('not implemented.')
+  },
+
+  messageBatchSendChannelCard: (call, callback) => {
+    void call
+    void callback
+    throw new Error('not implemented.')
+  },
+
   messageSendUrl: (call, callback) => {
     void call
     void callback


### PR DESCRIPTION
The generated IPuppetServer interface now includes the messageBatchSend RPC family, so the test server implementation needs matching not-implemented handlers to stay structurally complete.

Constraint: @juzi/wechaty-grpc@1.0.101 adds nine batch message RPCs

Confidence: high

Scope-risk: narrow

Tested: git diff --check

Not-tested: npm run lint:ts is blocked in this checkout by stale/missing generated commonjs/out exports unrelated to this mock implementation

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Wechaty gRPC here: https://wechaty.js.org/docs/contributing/

Happy contributing!

-->

#### Checklist

- [ ] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added
- [ ] CI has been passed. (GitHub actions all turns green)
- [ ] CLA has been signed

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://wechaty.js.org/docs/contributing/)?

#### Brief description of what is fixed or changed

#### Other comments

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Wechaty gRPC <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/wechaty/grpc/pull/<PR-id>
    <Component> Component affected by your changes such as csharp, go, java, etc.
-->
