### PR TITLE
Use trusted publishing for npm release

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -10,6 +10,10 @@ on:
       - 'proto/**'
       - 'src/**'
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     name: Build
@@ -86,10 +90,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
           registry-url: https://registry.npmjs.org/
           cache: npm
           cache-dependency-path: package.json
+
+      - name: Install latest npm
+        run: curl -qL https://www.npmjs.com/install.sh | sh
 
       - name: Set up TS
         run: npm install typescript@4.7.3
@@ -126,8 +133,6 @@ jobs:
           then echo "$NAME@$VERSION exists on NPM, skipped."
           else npm publish
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.JUZI_ADMIN_SCOPE_NPM_TOKEN }}
       - name: Is Not A Publish Branch
         if: steps.check-branch.outputs.match != 'true'
         run: echo 'Not A Publish Branch'


### PR DESCRIPTION
NPM access tokens now expire too quickly for this release workflow, and expired tokens cause publish to fail even after the package builds. Let the publish job use GitHub OIDC trusted publishing instead by granting id-token permission, using a trusted-publishing-capable Node/npm pair, and removing the old NODE_AUTH_TOKEN publish environment.\n\nConstraint: npm trusted publishing requires GitHub Actions OIDC permissions and a recent npm CLI\nRejected: Rotate JUZI_ADMIN_SCOPE_NPM_TOKEN | short-lived token would need repeated maintenance and still follows the deprecated release path\nConfidence: high\nScope-risk: narrow\nDirective: Register the npm package trusted publisher for juzibot/wechaty-grpc using workflow node.yml before relying on this publish job\nTested: Ruby YAML parse; git diff --check; workflow contains id-token permission and no NODE_AUTH_TOKEN\nNot-tested: Live npm publish because it requires npm-side trusted publisher registration

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Wechaty gRPC here: https://wechaty.js.org/docs/contributing/

Happy contributing!

-->

#### Checklist

- [ ] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added
- [ ] CI has been passed. (GitHub actions all turns green)
- [ ] CLA has been signed

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://wechaty.js.org/docs/contributing/)?

#### Brief description of what is fixed or changed

#### Other comments

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Wechaty gRPC <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/wechaty/grpc/pull/<PR-id>
    <Component> Component affected by your changes such as csharp, go, java, etc.
-->
