### PR TITLE
feat: call signaling RPCs — wire mirror of the puppet 1.0.138 call contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty-grpc",
-  "version": "1.0.101",
+  "version": "1.0.102",
   "description": "gRPC for Wechaty",
   "type": "module",
   "exports": {

--- a/proto/wechaty/puppet.proto
+++ b/proto/wechaty/puppet.proto
@@ -17,6 +17,7 @@ import "google/api/annotations.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 
 import "wechaty/puppet/base.proto";
+import "wechaty/puppet/call.proto";
 import "wechaty/puppet/contact.proto";
 import "wechaty/puppet/download-upload.proto";
 import "wechaty/puppet/event.proto";
@@ -384,6 +385,12 @@ service Puppet {
   rpc MessageCallRecord (puppet.MessageCallRecordRequest) returns (puppet.MessageCallRecordResponse) {
     option (google.api.http) = {
       get: "/message/{id}/call-record"
+    };
+  }
+  rpc CallControl (puppet.CallControlRequest) returns (puppet.CallControlResponse) {
+    option (google.api.http) = {
+      post: "/call/control"
+      body: "*"
     };
   }
   rpc MessageChatHistory (puppet.MessageChatHistoryRequest) returns (puppet.MessageChatHistoryResponse) {

--- a/proto/wechaty/puppet.proto
+++ b/proto/wechaty/puppet.proto
@@ -387,10 +387,52 @@ service Puppet {
       get: "/message/{id}/call-record"
     };
   }
-  rpc CallControl (puppet.CallControlRequest) returns (puppet.CallControlResponse) {
+  rpc CallInvite (puppet.CallInviteRequest) returns (puppet.CallInviteResponse) {
     option (google.api.http) = {
-      post: "/call/control"
+      post: "/call/invite"
       body: "*"
+    };
+  }
+  rpc CallAdd (puppet.CallAddRequest) returns (puppet.CallAddResponse) {
+    option (google.api.http) = {
+      post: "/call/{call_id}/add"
+      body: "*"
+    };
+  }
+  rpc CallAccept (puppet.CallAcceptRequest) returns (puppet.CallAcceptResponse) {
+    option (google.api.http) = {
+      post: "/call/{call_id}/accept"
+      body: "*"
+    };
+  }
+  rpc CallReject (puppet.CallRejectRequest) returns (puppet.CallRejectResponse) {
+    option (google.api.http) = {
+      post: "/call/{call_id}/reject"
+      body: "*"
+    };
+  }
+  rpc CallCancel (puppet.CallCancelRequest) returns (puppet.CallCancelResponse) {
+    option (google.api.http) = {
+      post: "/call/{call_id}/cancel"
+      body: "*"
+    };
+  }
+  rpc CallHangup (puppet.CallHangupRequest) returns (puppet.CallHangupResponse) {
+    option (google.api.http) = {
+      post: "/call/{call_id}/hangup"
+      body: "*"
+    };
+  }
+  // POST：签发可能在网关侧预分配媒体会话（有副作用），非幂等读取。
+  rpc CallMediaEndpoint (puppet.CallMediaEndpointRequest) returns (puppet.CallMediaEndpointResponse) {
+    option (google.api.http) = {
+      post: "/call/{call_id}/media-endpoint"
+      body: "*"
+    };
+  }
+  rpc CallPayload (puppet.CallPayloadRequest) returns (puppet.CallPayloadResponse) {
+    option (google.api.http) = {
+      get: "/call/{id}"
     };
   }
   rpc MessageChatHistory (puppet.MessageChatHistoryRequest) returns (puppet.MessageChatHistoryResponse) {

--- a/proto/wechaty/puppet/base.proto
+++ b/proto/wechaty/puppet/base.proto
@@ -5,6 +5,7 @@ option go_package       = "github.com/wechaty/go-grpc/wechaty/puppet";
 option java_package     = "io.github.wechaty.grpc.puppet";
 option csharp_namespace = "github.wechaty.grpc.puppet";
 
+// 数值必须与 @juzi/wechaty-puppet 的 DirtyType 严格一致。
 enum PayloadType {
   PAYLOAD_TYPE_UNSPECIFIED = 0;
   PAYLOAD_TYPE_MESSAGE     = 1;
@@ -15,6 +16,9 @@ enum PayloadType {
   PAYLOAD_TYPE_POST        = 6;
   PAYLOAD_TYPE_TAG         = 7;
   PAYLOAD_TYPE_TAG_GROUP   = 8;
+  PAYLOAD_TYPE_WXXD_PRODUCT = 9;
+  PAYLOAD_TYPE_WXXD_ORDER   = 10;
+  PAYLOAD_TYPE_CALL         = 11;
 }
 
 message StartRequest {}

--- a/proto/wechaty/puppet/call.proto
+++ b/proto/wechaty/puppet/call.proto
@@ -42,7 +42,7 @@ message CallControlRequest {
   string call_id    = 1; // 一通通话唯一 id：主叫生成 UUIDv4，全链路透传，禁止复用；控制面与媒体旁路以此关联
   CallSignal signal = 2;
   string peer_id    = 3; // 对端 contactId
-  CallType media    = 4; // signal=INVITE 时有效；复用既有 CallType（VOICE/VIDEO）
+  CallType media    = 4; // 必填：每个信令都须携带媒体类型（VOICE/VIDEO），复用既有 CallType；线上零值 CALL_TYPE_UNKNOWN 会被 server 拒绝
   string reason     = 5; // REJECT/HANGUP 可带；空串表示无
 }
 

--- a/proto/wechaty/puppet/call.proto
+++ b/proto/wechaty/puppet/call.proto
@@ -27,3 +27,23 @@ message CallRecordPayload {
   CallType type = 4;
   CallStatus status = 5;
 }
+
+enum CallSignal { // 通话控制信令枚举
+  CALL_SIGNAL_UNSPECIFIED = 0; // 未指定
+  CALL_SIGNAL_INVITE      = 1; // 主叫发起
+  CALL_SIGNAL_RINGING     = 2; // 被叫已响铃（回执）
+  CALL_SIGNAL_ACCEPT      = 3; // 被叫接听
+  CALL_SIGNAL_REJECT      = 4; // 被叫拒接
+  CALL_SIGNAL_CANCEL      = 5; // 接通前主叫取消
+  CALL_SIGNAL_HANGUP      = 6; // 接通后任一方挂断
+}
+
+message CallControlRequest {
+  string call_id    = 1; // 一通通话唯一 id（主叫生成，全链路透传）
+  CallSignal signal = 2;
+  string peer_id    = 3; // 对端 contactId
+  CallType media    = 4; // signal=INVITE 时有效；复用既有 CallType（VOICE/VIDEO）
+  string reason     = 5; // REJECT/HANGUP 可带；空串表示无
+}
+
+message CallControlResponse {}

--- a/proto/wechaty/puppet/call.proto
+++ b/proto/wechaty/puppet/call.proto
@@ -39,11 +39,13 @@ enum CallSignal { // 通话控制信令枚举
 }
 
 message CallControlRequest {
-  string call_id    = 1; // 一通通话唯一 id（主叫生成，全链路透传）
+  string call_id    = 1; // 一通通话唯一 id：主叫生成 UUIDv4，全链路透传，禁止复用；控制面与媒体旁路以此关联
   CallSignal signal = 2;
   string peer_id    = 3; // 对端 contactId
   CallType media    = 4; // signal=INVITE 时有效；复用既有 CallType（VOICE/VIDEO）
   string reason     = 5; // REJECT/HANGUP 可带；空串表示无
 }
 
+// 信令投递为 errors-only 契约：gRPC status error 仅表示传输失败或 puppet 不支持；
+// 对端的业务响应（响铃/接听/拒接/挂断）一律经 EVENT_TYPE_CALL 事件上行，本响应恒为空。
 message CallControlResponse {}

--- a/proto/wechaty/puppet/call.proto
+++ b/proto/wechaty/puppet/call.proto
@@ -5,6 +5,8 @@ option go_package       = "github.com/wechaty/go-grpc/wechaty/puppet";
 option java_package     = "io.github.wechaty.grpc.puppet";
 option csharp_namespace = "github.wechaty.grpc.puppet";
 
+import "google/protobuf/timestamp.proto";
+
 enum CallType {
   CALL_TYPE_UNKNOWN = 0; // 不明确
   CALL_TYPE_VOICE = 1; // 语音
@@ -15,7 +17,7 @@ enum CallStatus { // 类型枚举
   CALL_STATUS_UNKNOWN = 0; // 不明确
   CALL_STATUS_CANCELED = 1; // 自己取消
   CALL_STATUS_REJECTED = 2; // 对方拒接
-  CALL_STATUS_MISSED = 3; // 正在通话
+  CALL_STATUS_MISSED = 3; // 未接
   CALL_STATUS_ONGOING = 4; // 正在通话
   CALL_STATUS_ENDED = 5; // 已结束
 }
@@ -28,24 +30,100 @@ message CallRecordPayload {
   CallStatus status = 5;
 }
 
-enum CallSignal { // 通话控制信令枚举
-  CALL_SIGNAL_UNSPECIFIED = 0; // 未指定
-  CALL_SIGNAL_INVITE      = 1; // 主叫发起
-  CALL_SIGNAL_RINGING     = 2; // 被叫已响铃（回执）
-  CALL_SIGNAL_ACCEPT      = 3; // 被叫接听
-  CALL_SIGNAL_REJECT      = 4; // 被叫拒接
-  CALL_SIGNAL_CANCEL      = 5; // 接通前主叫取消
-  CALL_SIGNAL_HANGUP      = 6; // 接通后任一方挂断
+// 通话信令域全貌：
+// - 下行动作（业务侧 → 协议端）= CallInvite / CallAdd / CallAccept / CallReject / CallCancel / CallHangup
+//   六个独立 RPC（对齐 MessageSendText / MessageRecall / FriendshipAccept 的「一动作一 RPC」惯例）；
+// - CallMediaEndpoint 为媒体入场券：按需向协议端换取媒体网关协商入口（url/token），刻意不缓存；
+// - 状态面 = CallPayload 查询 + dirty(PAYLOAD_TYPE_CALL, id) 失效通知：协议端在任何通话状态变化时
+//   发 dirty，业务侧再经 CallPayload 拉取最新快照；
+// - 上行回执（ringing/accept/reject/cancel/hangup 及来电 invite）一律经 EVENT_TYPE_CALL 事件上行，
+//   payload 为 JSON 序列化的字符串（含 callId/signal/contactId/reason?/timestamp）；
+// - Ringing 没有下行 RPC：响铃回执是被叫协议端的自动行为，不是业务动作。
+
+// 发起呼叫请求：callId 不由主叫携带，而是由 puppet 实现侧生成并经 CallInviteResponse 返回。
+message CallInviteRequest {
+  // 受邀方 contactId 列表（不含发起方）：单元素 = 1v1 通话，多元素 = 群通话；
+  // 无论几人，一通通话只铸造一个 call_id。
+  repeated string contact_ids = 1;
+  CallType media = 2; // 必填：媒体类型（VOICE/VIDEO），复用既有 CallType；零值 CALL_TYPE_UNKNOWN 会被 server 拒绝
 }
 
-message CallControlRequest {
-  string call_id    = 1; // 一通通话唯一 id：主叫生成 UUIDv4，全链路透传，禁止复用；控制面与媒体旁路以此关联
-  CallSignal signal = 2;
-  string peer_id    = 3; // 对端 contactId
-  CallType media    = 4; // 必填：每个信令都须携带媒体类型（VOICE/VIDEO），复用既有 CallType；线上零值 CALL_TYPE_UNKNOWN 会被 server 拒绝
-  string reason     = 5; // REJECT/HANGUP 可带；空串表示无
+// CallInvite 响应：
+// - call_id 由 puppet 实现侧（协议端）生成并经本响应返回，全链路以此关联控制面与媒体旁路；
+// - 上行 EVENT_TYPE_CALL 事件可能先于本响应到达，客户端须容忍乱序；
+// - 后续控制 RPC（CallAccept/CallReject/CallCancel/CallHangup）凭此 call_id 引用本通通话。
+message CallInviteResponse {
+  string call_id = 1;
 }
 
-// 信令投递为 errors-only 契约：gRPC status error 仅表示传输失败或 puppet 不支持；
-// 对端的业务响应（响铃/接听/拒接/挂断）一律经 EVENT_TYPE_CALL 事件上行，本响应恒为空。
-message CallControlResponse {}
+// 通话中途拉人（errors-only 契约）：
+// - 新参与者的应答回执（响铃/接听/拒接）一律经 EVENT_TYPE_CALL 事件上行，本响应恒为空；
+// - 拉人特有的失败（通话不存在/已结束、人数上限等）经 gRPC status error 返回。
+message CallAddRequest {
+  string call_id = 1; // 由 CallInvite 响应获得
+  repeated string contact_ids = 2; // 新增受邀方 contactId 列表（不含已在通话中的参与者）
+}
+
+message CallAddResponse {}
+
+// 以下四个控制 RPC（CallAccept/CallReject/CallCancel/CallHangup）的信令投递为 errors-only 契约：
+// gRPC status error 仅表示传输失败或 puppet 不支持；对端的业务响应（响铃/接听/拒接/挂断）
+// 一律经 EVENT_TYPE_CALL 事件上行，故四个响应消息恒为空。
+
+// 被叫接听来电。
+message CallAcceptRequest {
+  string call_id = 1; // 由 CallInvite 响应获得；协议端持有会话状态，凭此即可定位会话（无需 peer/media）
+}
+
+message CallAcceptResponse {}
+
+// 被叫拒接来电。
+message CallRejectRequest {
+  string call_id = 1; // 由 CallInvite 响应获得；协议端持有会话状态，凭此即可定位会话（无需 peer/media）
+  string reason  = 2; // 可空，空串表示无
+}
+
+message CallRejectResponse {}
+
+// 接通前主叫取消呼叫。
+message CallCancelRequest {
+  string call_id = 1; // 由 CallInvite 响应获得；协议端持有会话状态，凭此即可定位会话（无需 peer/media）
+}
+
+message CallCancelResponse {}
+
+// 接通后任一方挂断。
+message CallHangupRequest {
+  string call_id = 1; // 由 CallInvite 响应获得；协议端持有会话状态，凭此即可定位会话（无需 peer/media）
+  string reason  = 2; // 可空，空串表示无
+}
+
+message CallHangupResponse {}
+
+// 媒体入场券：按 call_id 向协议端换取媒体网关协商入口。
+// 签发可能在网关侧预分配媒体会话（有副作用），故服务端不得缓存响应、客户端按需拉取。
+message CallMediaEndpointRequest {
+  string call_id = 1; // 由 CallInvite 响应获得
+}
+
+message CallMediaEndpointResponse {
+  string url      = 1; // 媒体网关协商入口（非媒体流地址本身）
+  string token    = 2; // 短时效凭证，绑定 call_id + 本端身份
+  google.protobuf.Timestamp expires_at = 3; // 凭证过期时刻；不设置 = 不过期；过期后重新拉取本 RPC
+  string protocol = 4; // 入口方言（如 whip / livekit / 自定义），由媒体 SDK 消费
+}
+
+// 通话状态快照查询（对齐 ContactPayload 的实体查询模式）：
+// 协议端在任何通话状态变化时须发 dirty(PAYLOAD_TYPE_CALL, id)，业务侧凭此失效缓存后重新拉取。
+message CallPayloadRequest {
+  string id = 1; // call_id
+}
+
+message CallPayloadResponse {
+  string id      = 1;
+  string starter = 2; // 发起方 contactId；空串 = 协议端不可知（如中途被拉入者视角）
+  repeated string participants = 3; // 当前全量参与者名册
+  CallType media = 4; // 当前媒体类型（语音↔视频切换经 dirty 反映）
+  google.protobuf.Timestamp start_time = 5; // 通话发起时刻；接通时刻不在此（等于上行 Accept 事件的 timestamp）
+  google.protobuf.Timestamp end_time   = 6; // 通话结束时刻；未设置 = 通话进行中
+}

--- a/proto/wechaty/puppet/event.proto
+++ b/proto/wechaty/puppet/event.proto
@@ -34,6 +34,7 @@ enum EventType {
   EVENT_TYPE_ROOM_ANNOUNCE = 32;
   EVENT_TYPE_VERIFY_CODE   = 33;
   EVENT_TYPE_VERIFY_SLIDE  = 34;
+  EVENT_TYPE_CALL          = 35;
 }
 
 message EventRequest {

--- a/tests/puppet-server-impl.ts
+++ b/tests/puppet-server-impl.ts
@@ -196,6 +196,12 @@ export const puppetServerImpl: IPuppetServer = {
     throw new Error('not implemented.')
   },
 
+  callControl: (call, callback) => {
+    void call
+    void callback
+    throw new Error('not implemented.')
+  },
+
   messageChatHistory: (call, callback) => {
     void call
     void callback

--- a/tests/puppet-server-impl.ts
+++ b/tests/puppet-server-impl.ts
@@ -196,7 +196,49 @@ export const puppetServerImpl: IPuppetServer = {
     throw new Error('not implemented.')
   },
 
-  callControl: (call, callback) => {
+  callInvite: (call, callback) => {
+    void call
+    void callback
+    throw new Error('not implemented.')
+  },
+
+  callAdd: (call, callback) => {
+    void call
+    void callback
+    throw new Error('not implemented.')
+  },
+
+  callAccept: (call, callback) => {
+    void call
+    void callback
+    throw new Error('not implemented.')
+  },
+
+  callReject: (call, callback) => {
+    void call
+    void callback
+    throw new Error('not implemented.')
+  },
+
+  callCancel: (call, callback) => {
+    void call
+    void callback
+    throw new Error('not implemented.')
+  },
+
+  callHangup: (call, callback) => {
+    void call
+    void callback
+    throw new Error('not implemented.')
+  },
+
+  callMediaEndpoint: (call, callback) => {
+    void call
+    void callback
+    throw new Error('not implemented.')
+  },
+
+  callPayload: (call, callback) => {
     void call
     void callback
     throw new Error('not implemented.')


### PR DESCRIPTION
## 概述

为 gRPC 协议层新增**通话信令域**（1.0.102），是已发布的 [@juzi/wechaty-puppet@1.0.138 call 契约](https://github.com/juzibot/wechaty-puppet/pull/93) 的 wire 镜像。配套的 wechaty-puppet-service / wechaty 适配在后续 PR。

## 契约全貌

### 下行：六个动作 RPC（errors-only，响应恒空）

| RPC | HTTP | 说明 |
|---|---|---|
| `CallInvite(contact_ids[], media) → {call_id}` | POST /call/invite | 发起呼叫；单元素=1v1，多元素=群通话；**call_id 由协议端铸造**经响应返回 |
| `CallAdd(call_id, contact_ids[])` | POST /call/{call_id}/add | 中途拉人 |
| `CallAccept(call_id)` | POST /call/{call_id}/accept | 接听 |
| `CallReject(call_id, reason)` | POST /call/{call_id}/reject | 拒接 |
| `CallCancel(call_id)` | POST /call/{call_id}/cancel | 接通前取消 |
| `CallHangup(call_id, reason)` | POST /call/{call_id}/hangup | 挂断 |

业务回执（响铃/接听/拒接/挂断）一律经 `EVENT_TYPE_CALL = 35` 事件上行，payload 为 JSON：`{callId, signal, contactId(actor), reason?, timestamp(ms)}`。Ringing 无下行 RPC（被叫协议端自动回执）。

### 媒体与状态

| RPC | HTTP | 说明 |
|---|---|---|
| `CallMediaEndpoint(call_id) → {url, token, expires_at, protocol}` | POST /call/{call_id}/media-endpoint | 直连网关媒体「入场券」；POST 因签发可能预分配网关会话，**不得缓存** |
| `CallPayload(id) → {id, starter, participants[], media, start_time, end_time}` | GET /call/{id} | 通话状态快照（ContactPayload 模式）；starter 空串=不可知，end_time 未设=进行中；状态变化经 `dirty(PAYLOAD_TYPE_CALL, id)` 失效 |

时间字段用 `google.protobuf.Timestamp`（仓库新惯例）；接通时刻不在 payload——等于上行 Accept 事件的 timestamp。

### 数值契约

`PayloadType` 补 `WXXD_PRODUCT = 9` / `WXXD_ORDER = 10`（历史欠账回填，防止数值空间被误分配）与 **`CALL = 11`**，与 puppet `DirtyType` 严格逐值对齐。`EVENT_TYPE_CALL = 35` 顺延追加，既有枚举值零变动。

## 自查

- proto 全图编译、OpenAPI 生成（8 条 call 路径）、tests stub 与 RPC 1:1（8↔8）
- `npm run dist` / `lint:es` / `lint:ts` / `test:unit` 全绿
- 1 轮 cto-loop：零 CRITICAL/HIGH/MEDIUM；唯一 LOW（main 既有的 CALL_STATUS_MISSED 注释 typo）已顺手修复