### PR TITLE
feat: add MessageVoice / MessageVoiceText RPC

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty-grpc",
-  "version": "1.0.103",
+  "version": "1.0.104",
   "description": "gRPC for Wechaty",
   "type": "module",
   "exports": {

--- a/proto/wechaty/puppet.proto
+++ b/proto/wechaty/puppet.proto
@@ -348,6 +348,12 @@ service Puppet {
   rpc MessageImage (puppet.MessageImageRequest) returns (puppet.MessageImageResponse) {
   }
 
+  rpc MessageVoice (puppet.MessageVoiceRequest) returns (puppet.MessageVoiceResponse) {
+  }
+
+  rpc MessageVoiceText (puppet.MessageVoiceTextRequest) returns (puppet.MessageVoiceTextResponse) {
+  }
+
   rpc MessageSendFile (puppet.MessageSendFileRequest) returns (puppet.MessageSendFileResponse) {
   }
 

--- a/proto/wechaty/puppet/message.proto
+++ b/proto/wechaty/puppet/message.proto
@@ -112,6 +112,21 @@ message MessageFileResponse {
    string file_box = 1;
 }
 
+message MessageVoiceRequest {
+  string id = 1;
+}
+message MessageVoiceResponse {
+   string file_box = 1;
+}
+
+message MessageVoiceTextRequest {
+  string id = 1;
+}
+message MessageVoiceTextResponse {
+   string text      = 1;
+   bool   no_speech = 2;
+}
+
 message MessageMiniProgramRequest {
   string id = 1;
 }


### PR DESCRIPTION
## What

Add two gRPC methods symmetric to `MessageImage` / `MessageFile`:

- `MessageVoice` → `MessageVoiceResponse { file_box }`
- `MessageVoiceText` → `MessageVoiceTextResponse { text, no_speech }`

plus their request messages. Stubs regenerate via `scripts/generate-stub.sh` at publish.

## Why

Carries voice file + voice-to-text (ASR) as second requests instead of forcing ASR into the synchronous message payload. `no_speech` distinguishes "confirmed no speech" from "not yet ready", so consumers skip a redundant **paid** ASR call.

## Scope

Pure additive proto. Version `1.0.103 → 1.0.104`. Part of: wechaty-puppet → **wechaty-grpc** → wechaty-puppet-service → wechaty → xiaoju-bot-nested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCmXBqNF3QhpbLnQJTqgR2
