### PR TITLE
fix: implement messageVoice / messageVoiceText in test server fixture

### DIFF
--- a/tests/puppet-server-impl.ts
+++ b/tests/puppet-server-impl.ts
@@ -262,6 +262,18 @@ export const puppetServerImpl: IPuppetServer = {
     throw new Error('not implemented.')
   },
 
+  messageVoice: (call, callback) => {
+    void call
+    void callback
+    throw new Error('not implemented.')
+  },
+
+  messageVoiceText: (call, callback) => {
+    void call
+    void callback
+    throw new Error('not implemented.')
+  },
+
   messageLocation: (call, callback) => {
     void call
     void callback


### PR DESCRIPTION
## Problem

PR #74 (MessageVoice / MessageVoiceText RPC) merged with a red CI Build. The generated `IPuppetServer` now requires handlers for the two new RPCs, but the test fixture `tests/puppet-server-impl.ts` did not implement them:

```
tests/puppet-server-impl.ts(11,14): error TS2739: ... is missing the following
properties from type 'IPuppetServer': messageVoice, messageVoiceText
ERROR: "lint:ts" exited with 2.
```

## Fix

Add the two stub handlers (same `throw new Error('not implemented.')` pattern as the other message handlers).

## Verified

`npm run lint` (es + ts + proto) passes locally; `lint:ts` is now clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCmXBqNF3QhpbLnQJTqgR2
