### PR TITLE
feat: add BatchRoomPayload RPC

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty-grpc",
-  "version": "1.0.104",
+  "version": "1.0.105",
   "description": "gRPC for Wechaty",
   "type": "module",
   "exports": {

--- a/proto/wechaty/puppet.proto
+++ b/proto/wechaty/puppet.proto
@@ -604,6 +604,13 @@ service Puppet {
     };
   }
 
+  rpc BatchRoomPayload (puppet.BatchRoomPayloadRequest) returns (puppet.BatchRoomPayloadResponse) {
+    option (google.api.http) = {
+      post: "/rooms/batch-payload"
+      body: "*"
+    };
+  }
+
   rpc RoomList (puppet.RoomListRequest) returns (puppet.RoomListResponse) {
     option (google.api.http) = {
       get: "/rooms"

--- a/proto/wechaty/puppet/room.proto
+++ b/proto/wechaty/puppet/room.proto
@@ -171,3 +171,11 @@ message RoomDismissRequest {
 }
 
 message RoomDismissResponse {}
+
+message BatchRoomPayloadRequest {
+  repeated string ids = 1;
+}
+
+message BatchRoomPayloadResponse {
+  repeated RoomPayloadResponse room_payloads = 1;
+}

--- a/tests/puppet-server-impl.ts
+++ b/tests/puppet-server-impl.ts
@@ -526,6 +526,12 @@ export const puppetServerImpl: IPuppetServer = {
     throw new Error('not implemented.')
   },
 
+  batchRoomPayload: (call, callback) => {
+    void call
+    void callback
+    throw new Error('not implemented.')
+  },
+
   roomQRCode: (call, callback) => {
     void call
     void callback


### PR DESCRIPTION
## Summary

- New `BatchRoomPayload` unary RPC mirroring the existing `BatchContactPayload`
- Request: `repeated string ids`; Response: `repeated RoomPayloadResponse room_payloads`
- HTTP gateway: `POST /rooms/batch-payload`
- `tests/puppet-server-impl.ts` stub added for `IPuppetServer` exhaustive check

## Why

Backing infrastructure for `findAllIter` in wechaty, which needs a single RPC to
batch-fetch room payloads instead of N round trips per id (currently 100k contacts
takes ~30 min via per-id RPC).

This is the first of 4 coordinated PRs across:
wechaty-grpc → wechaty-puppet → wechaty-puppet-service → wechaty.

Each subsequent PR depends on the previous one being merged and the corresponding
npm package being published.

## Coordinated PRs

- [x] **wechaty-grpc** — this PR
- [ ] wechaty-puppet — adds `batchRoomPayload` + abstract `batchRoomRawPayload` (mirrors contact-mixin)
- [ ] wechaty-puppet-service — wires client + server through the new RPC
- [ ] wechaty — adds `Contact.findAllIter` / `Room.findAllIter` async generators

## Test plan

- [x] `npm run lint` — pass
- [x] `npm run generate` regenerates `out/*` with `BatchRoomPayload` exports verified
- [x] `npm test` (24 spec) — pass
- [ ] Downstream PRs compile against this version after npm publish