### PR TITLE
feat: add call_id to CallRecordPayload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty-grpc",
-  "version": "1.0.105",
+  "version": "1.0.106",
   "description": "gRPC for Wechaty",
   "type": "module",
   "exports": {

--- a/proto/wechaty/puppet/call.proto
+++ b/proto/wechaty/puppet/call.proto
@@ -28,6 +28,7 @@ message CallRecordPayload {
   int32 length = 3;
   CallType type = 4;
   CallStatus status = 5;
+  string call_id = 6; // 关联控制面 call_id，可空字符串表示历史/未知
 }
 
 // 通话信令域全貌：


### PR DESCRIPTION
## Summary

Add `string call_id = 6;` to `CallRecordPayload` in `proto/wechaty/puppet/call.proto`. Downstream `wechaty-puppet` consumes this field to correlate call records with their originating call session. Bumped package version to `1.0.106` and regenerated grpc stubs + dist accordingly.

## Test plan

- [x] `npm run lint` green
- [x] `npm test` (tap) green
- [x] `npm run generate` regenerated proto stubs
- [x] `dist/` rebuilt and committed